### PR TITLE
Support for Foo::SomeMessage.decode_from(stream)

### DIFF
--- a/lib/protobuf/message/serialization.rb
+++ b/lib/protobuf/message/serialization.rb
@@ -11,6 +11,10 @@ module Protobuf
           new.decode(bytes)
         end
 
+        def decode_from(stream)
+          new.decode_from(stream)
+        end
+
         # Create a new object with the given values and return the encoded bytes.
         def encode(fields = {})
           new(fields).encode

--- a/spec/lib/protobuf/message_spec.rb
+++ b/spec/lib/protobuf/message_spec.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+require 'stringio'
 require 'spec_helper'
 
 RSpec.describe Protobuf::Message do
@@ -68,6 +69,15 @@ RSpec.describe Protobuf::Message do
           expect { older.enum_field = [:HOORAY] }.to raise_error
         end
       end
+    end
+  end
+
+  describe '.decode_from' do
+    let(:message) { ::Test::Resource.new(:name => "Jim") }
+
+    it 'creates a new message object decoded from the given byte stream' do
+      stream = ::StringIO.new(message.encode)
+      expect(::Test::Resource.decode_from(stream)).to eq message
     end
   end
 


### PR DESCRIPTION
The Serialization documentation:
  https://github.com/localshred/protobuf/wiki/Serialization
implies that the following idioms should work for decoding an object:
  Foo::User.decode(bytes)
  Foo::User.decode_from(stream)
However, in practice, decode_from(...) only seems to be supported as an instance
method, not a class method.  By comparison, decode(...) is supported as both an
instance method and a class method.  Let's fix that.