### PR TITLE
Allow the Message to be constructed with a block.

### DIFF
--- a/lib/protobuf/message.rb
+++ b/lib/protobuf/message.rb
@@ -26,11 +26,15 @@ module Protobuf
     # Constructor
     #
 
-    def initialize(fields = {})
+    def initialize(fields = {}, &blk)
       @values = {}
 
-      fields.to_hash.each_pair do |name, value|
-        self[name] = value
+      if blk
+        blk.call(self)
+      else
+        fields.to_hash.each_pair do |name, value|
+          self[name] = value
+        end
       end
     end
 

--- a/spec/lib/protobuf/message_spec.rb
+++ b/spec/lib/protobuf/message_spec.rb
@@ -175,6 +175,12 @@ RSpec.describe Protobuf::Message do
       expect(test_enum.non_default_enum).to eq(2)
     end
 
+    it "initializes with an object with a block" do
+      hashie_object = OpenStruct.new(:to_hash => { :non_default_enum => 2 })
+      test_enum = Test::EnumTestMessage.new { |p| p.non_default_enum = 2 }
+      expect(test_enum.non_default_enum).to eq(2)
+    end
+
     context 'ignoring unknown fields' do
       before { ::Protobuf.ignore_unknown_fields = true }
 

--- a/spec/lib/protobuf/message_spec.rb
+++ b/spec/lib/protobuf/message_spec.rb
@@ -176,7 +176,6 @@ RSpec.describe Protobuf::Message do
     end
 
     it "initializes with an object with a block" do
-      hashie_object = OpenStruct.new(:to_hash => { :non_default_enum => 2 })
       test_enum = Test::EnumTestMessage.new { |p| p.non_default_enum = 2 }
       expect(test_enum.non_default_enum).to eq(2)
     end


### PR DESCRIPTION
We commonly use the following idiom:

```ruby
Protobuf::Message.new.tap do |p|
  p.field = x
  ...
end
```

This patch allows the following:
```ruby
Protobuf::Message.new do |p|
  p.field = x
  ...
end
```