### PR TITLE
restart service listener if it dies

### DIFF
--- a/lib/protobuf/rpc/service_directory.rb
+++ b/lib/protobuf/rpc/service_directory.rb
@@ -95,13 +95,10 @@ module Protobuf
       end
 
       def lookup(service)
-        if running?
-          start_listener_thread if listener_dead?
-
-          if @listings_by_service.key?(service.to_s)
-            @listings_by_service[service.to_s].entries.sample
-          end
-        end
+        return unless running?
+        start_listener_thread if listener_dead?
+        return unless @listings_by_service.key?(service.to_s)
+        @listings_by_service[service.to_s].entries.sample
       end
 
       def listener_dead?

--- a/lib/protobuf/rpc/service_filters.rb
+++ b/lib/protobuf/rpc/service_filters.rb
@@ -94,10 +94,10 @@ module Protobuf
         # if the filter should not be invoked, true if invocation should occur.
         #
         def invoke_filter?(rpc_method, filter)
-          invoke_via_only?(rpc_method, filter) \
-            && invoke_via_except?(rpc_method, filter) \
-            && invoke_via_if?(rpc_method, filter) \
-            && invoke_via_unless?(rpc_method, filter)
+          invoke_via_only?(rpc_method, filter) &&
+            invoke_via_except?(rpc_method, filter) &&
+            invoke_via_if?(rpc_method, filter) &&
+            invoke_via_unless?(rpc_method, filter)
         end
 
         # If the target rpc endpoint method is listed under an :except option,


### PR DESCRIPTION
the service directory thread can die (for a myriad of reasons), this PR restarts when a lookup request is made if the service directory has been stopped