### PR TITLE
Fix unhandled error in trap signal handler

### DIFF
--- a/lib/protobuf/rpc/servers/zmq_runner.rb
+++ b/lib/protobuf/rpc/servers/zmq_runner.rb
@@ -41,7 +41,7 @@ module Protobuf
             logger.info do
               <<-THREAD_TRACE
                 #{thread.inspect}:
-                  #{thread.backtrace.join($INPUT_RECORD_SEPARATOR)}"
+                  #{thread.backtrace.try(:join, $INPUT_RECORD_SEPARATOR)}"
               THREAD_TRACE
             end
           end


### PR DESCRIPTION
Thread#backtrace can be nil.  If this is the case, this signal handler
will throw an error and terminate the process.  In the case of nil here,
we will just print nothing and continue on.