### PR TITLE
Move input file expansion into Ruby

### DIFF
--- a/lib/protobuf/tasks/compile.rake
+++ b/lib/protobuf/tasks/compile.rake
@@ -18,8 +18,7 @@ namespace :protobuf do
     command << "protoc"
     command << "--#{args[:plugin]}_out=#{args[:destination]}"
     command << "-I #{args[:source]}"
-    command << "#{args[:source]}/#{args[:package]}/*.proto"
-    command << "#{args[:source]}/#{args[:package]}/**/*.proto"
+    command << Dir["#{args[:source]}/#{args[:package]}/**/*.proto"].join(" ")
     full_command = command.join(' ')
 
     puts full_command


### PR DESCRIPTION
#### What's this PR do?

The `rake protobuf:compile` task previously made an assumption about the implementing project having proto files directly under the package root as well as in some sub-directories.  If your system shell is configured as `bash`, the directory expansion would fail, resulting an an error message from `protoc`.

```
$ bundle exec rake protobuf:compile['package']
protoc --ruby_out=lib -I definitions definitions/package/*.proto definitions/package/**/*.proto
definitions/package/**/*.proto: No such file or directory
```

This PR adjusts the rake task to do the globing in Ruby, bypassing the shortcomings of `bash` and providing a more future-proof solution.

#### How should this be manually tested?

Adjust your system shell to bash.  Create a sandbox project with a single `.proto` file in the package directory.  Run `rake protobuf:compile` and ensure that the `protoc` command succeeds.

#### Any additional context you want to provide?

:heart: protobufs 

We wanted to add some unit tests for this, but didn't as of the submission of this PR since our approach would be to extract the functionality behind the `protobuf:compile` task to an object, then test that object directly and invoke that object from the rake task. We weren't sure if that was a refactor / stance you cared to introduce, so we just wanted to ask about it first before doing the work.

\+ @jtrim